### PR TITLE
Feature/driver mock 3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 smartlamp-brightnessd/
 tasks-daemon-2026/
+.probe_2025*
+probe_2025*
+.*.cmd
+Module.symvers
+modules.order

--- a/esp32/.gitignore
+++ b/esp32/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/esp32/.vscode/extensions.json
+++ b/esp32/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/esp32/include/README
+++ b/esp32/include/README
@@ -1,0 +1,37 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the convention is to give header files names that end with `.h'.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/esp32/lib/README
+++ b/esp32/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into the executable file.
+
+The source code of each library should be placed in a separate directory
+("lib/your_library_name/[Code]").
+
+For example, see the structure of the following example libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional. for custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+Example contents of `src/main.c` using Foo and Bar:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+The PlatformIO Library Dependency Finder will find automatically dependent
+libraries by scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -1,0 +1,16 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+upload_speed = 115200
+monitor_speed = 115200

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -1,0 +1,29 @@
+#include <Arduino.h>
+
+const int baudrate = 115200;
+const int ledPin = 13;
+const int ldrPin = 36;
+
+void setup() {
+  Serial.begin(baudrate);
+  // Serial.println("Hello World!");
+  Serial.println("Write something: ");
+  pinMode(ledPin, OUTPUT);
+  pinMode(ldrPin, INPUT);
+}
+
+void loop() {
+  if (Serial.available() > 0) {
+    String input = Serial.readString();
+    Serial.println("You wrote: " + input);
+  }
+
+  // digitalWrite(ledPin, HIGH);
+  // delay(1000);
+  // digitalWrite(ledPin, LOW);
+  delay(100);
+
+  int value = analogRead(ldrPin);
+  Serial.println(value);
+
+}

--- a/esp32/test/README
+++ b/esp32/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Test Runner and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/en/latest/advanced/unit-testing/index.html

--- a/smartlamp-kernel-module/Makefile
+++ b/smartlamp-kernel-module/Makefile
@@ -6,7 +6,7 @@
 #   Tarefa 2.3: obj-m += serial_read_2025.o
 #   Tarefa 2.4: obj-m += sysfs_2025.o
 #   Tarefa 3.1: obj-m += test_driver.o
-obj-m += ALTERE_PARA_O_ARQUIVO_DA_TASK.o
+obj-m += test_driver.o
 PWD := $(CURDIR)
 
 all:

--- a/smartlamp-kernel-module/Makefile
+++ b/smartlamp-kernel-module/Makefile
@@ -6,7 +6,7 @@
 #   Tarefa 2.3: obj-m += serial_read_2025.o
 #   Tarefa 2.4: obj-m += sysfs_2025.o
 #   Tarefa 3.1: obj-m += test_driver.o
-obj-m += ALTERE_PARA_O_ARQUIVO_DA_TASK.o
+obj-m += obj-m += test_driver.o
 PWD := $(CURDIR)
 
 all:

--- a/smartlamp-kernel-module/Makefile
+++ b/smartlamp-kernel-module/Makefile
@@ -6,7 +6,7 @@
 #   Tarefa 2.3: obj-m += serial_read_2025.o
 #   Tarefa 2.4: obj-m += sysfs_2025.o
 #   Tarefa 3.1: obj-m += test_driver.o
-obj-m += obj-m += test_driver.o
+obj-m += ALTERE_PARA_O_ARQUIVO_DA_TASK.o
 PWD := $(CURDIR)
 
 all:

--- a/smartlamp-kernel-module/probe_2025.c
+++ b/smartlamp-kernel-module/probe_2025.c
@@ -14,8 +14,8 @@ static uint usb_in, usb_out;                       // Endereços das portas de e
 static char *usb_in_buffer, *usb_out_buffer;       // Buffers de entrada e saída da USB
 static int usb_max_size;                           // Tamanho máximo de uma mensagem USB
 
-#define VENDOR_ID   SUBSTITUA_PELO_VENDORID /* Encontre o VendorID  do smartlamp */
-#define PRODUCT_ID  SUBSTITUA_PELO_PRODUCTID /* Encontre o ProductID do smartlamp */
+#define VENDOR_ID   0x10c4 /* Encontre o VendorID  do smartlamp */
+#define PRODUCT_ID  0xea60 /* Encontre o ProductID do smartlamp */
 static const struct usb_device_id id_table[] = { { USB_DEVICE(VENDOR_ID, PRODUCT_ID) }, {} };
 
 static int  usb_probe(struct usb_interface *ifce, const struct usb_device_id *id); // Executado quando o dispositivo é conectado na USB

--- a/smartlamp-kernel-module/test_driver.c
+++ b/smartlamp-kernel-module/test_driver.c
@@ -89,6 +89,15 @@ static ssize_t attr_store(struct kobject *sys_obj, struct kobj_attribute *attr, 
     value = clamp_percent(value);
     (void)attr_name;
 
+    if(strcmp(attr_name,"ldr")) {
+        mock_ldr = value;
+    }
+    if(strcmp(attr_name,"led")) {
+        mock_led = value;
+    }
+    if(strcmp(attr_name,"threshold")) {
+        mock_threshold = value;
+    }
     // TASK 3.1: esta funcao e chamada quando o usuario escreve em um arquivo.
     // Exemplo: echo 75 | sudo tee /sys/kernel/smartlamp/ldr
     //

--- a/smartlamp-kernel-module/test_driver.c
+++ b/smartlamp-kernel-module/test_driver.c
@@ -51,6 +51,15 @@ static ssize_t attr_show(struct kobject *sys_obj, struct kobj_attribute *attr, c
     (void)sys_obj;
     (void)attr_name;
 
+    if(strcmp(attr_name,"ldr")) {
+        value = mock_ldr;
+    }
+    if(strcmp(attr_name,"led")) {
+        value = mock_led;
+    }
+    if(strcmp(attr_name,"threshold")) {
+        value = mock_threshold;
+    }
     // TASK 3.1: esta funcao e chamada quando o usuario le um arquivo com cat.
     // Exemplo: cat /sys/kernel/smartlamp/ldr
     //

--- a/smartlamp-kernel-module/test_driver.c
+++ b/smartlamp-kernel-module/test_driver.c
@@ -14,10 +14,6 @@ static struct kobj_attribute led_attribute = __ATTR(led, 0664, attr_show, attr_s
 static struct kobj_attribute ldr_attribute = __ATTR(ldr, 0664, attr_show, attr_store);
 static struct kobj_attribute threshold_attribute = __ATTR(threshold, 0664, attr_show, attr_store);
 
-static int mock_led = 0;
-static int mock_ldr = 0;
-static int mock_threshold = 0;
-
 static struct attribute *attrs[] = {
     &led_attribute.attr,
     &ldr_attribute.attr,

--- a/smartlamp-kernel-module/test_driver.c
+++ b/smartlamp-kernel-module/test_driver.c
@@ -14,6 +14,10 @@ static struct kobj_attribute led_attribute = __ATTR(led, 0664, attr_show, attr_s
 static struct kobj_attribute ldr_attribute = __ATTR(ldr, 0664, attr_show, attr_store);
 static struct kobj_attribute threshold_attribute = __ATTR(threshold, 0664, attr_show, attr_store);
 
+static int mock_led = 0;
+static int mock_ldr = 0;
+static int mock_threshold = 0;
+
 static struct attribute *attrs[] = {
     &led_attribute.attr,
     &ldr_attribute.attr,


### PR DESCRIPTION
## Passos

- [x] Passo 1: Abrir `test_driver.c`.
- [x] Passo 2: Localizar a variavel `attr_name` em `attr_show()` e `attr_store()`.
- [x] Passo 3: Implementar `attr_show()` para retornar `mock_led`, `mock_ldr` ou `mock_threshold`.
- [x] Passo 4: Implementar `attr_store()` para atualizar `mock_led`, `mock_ldr` ou `mock_threshold`.
- [x] Passo 5: Confirmar que os valores ficam limitados entre 0 e 100 usando a funcao `clamp_percent()`.
- [x] Passo 6: Atualizar o `Makefile` para compilar `test_driver.o`.
- [x] Passo 7: Compilar com `make`.
- [x] Passo 8: Carregar o modulo com `sudo insmod test_driver.ko`.
- [x] Passo 9: Testar leitura e escrita nos arquivos em `/sys/kernel/smartlamp`.